### PR TITLE
Fix #27, segmentation fault when c_tags is null

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -547,6 +547,9 @@ impl Metadata {
         let mut vals = vec![];
         unsafe {
             let c_vals = gexiv2::gexiv2_metadata_get_tag_multiple(self.raw, c_str_tag.as_ptr());
+            if(c_vals.is_null()) {
+                return Ok(vals);
+            }
             let mut cur_offset = 0;
             while !(*c_vals.offset(cur_offset)).is_null() {
                 let value = ffi::CStr::from_ptr(*c_vals.offset(cur_offset)).to_str();


### PR DESCRIPTION
Since I applied your `while` patch, was `free_array_of_pointers` still called after the loop and caused another segfault. Just tell me if you would like me to change to `if` instead :)