### PR TITLE
Provide a wrapper for gexiv2::gexiv2_initialize

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,3 +8,4 @@ Contributors
 * Einar Gangsø
 * Eric Trombly
 * Huon Wilson
+* Wieland Hoffmann

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -832,6 +832,26 @@ pub fn get_tag_type(tag: &str) -> Result<TagType> {
     }
 }
 
+/// Initialize gexiv2.
+///
+/// This must be called in a thread-safe fashion before using rexiv2 in
+/// multi-threaded applications.
+///
+/// # Example
+/// ```
+/// use std::sync::{Once, ONCE_INIT};
+/// fn main() {
+///     static START: Once = ONCE_INIT;
+///
+///     START.call_once(|| unsafe {
+///         rexiv2::initialize().expect("Unable to initialize rexiv2");
+///     });
+/// }
+/// ```
+pub fn initialize() -> Result<()> {
+    unsafe { int_bool_to_result(gexiv2::gexiv2_initialize()) }
+}
+
 
 // XMP namespace management.
 


### PR DESCRIPTION
gexiv2_initialize is required to be called in multi-threaded applications,
because otherwise the program might crash with multiple threads having stack
traces ending in:

> (gdb) bt
> 0  0x00007ffff7cb6f04 in __memcmp_avx2_movbe () at /usr/lib/libc.so.6
> 1  0x00007ffff758be98 in std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > >::_M_get_insert_hint_unique_pos(std::_Rb_tree_const_iterator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) () at /usr/lib/libexiv2.so.26
> 2  0x00007ffff76b727a in  () at /usr/lib/libexiv2.so.26
> 3  0x00007ffff76b7759 in  () at /usr/lib/libexiv2.so.26
> 4  0x00007ffff7691d8d in  () at /usr/lib/libexiv2.so.26
> 5  0x00007ffff7680c85 in TXMPMeta<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::RegisterNamespace(char const*, char const*) () at /usr/lib/libexiv2.so.26
> 6  0x00007ffff767c320 in Exiv2::XmpParser::initialize(void (*)(void*, bool), void*) () at /usr/lib/libexiv2.so.26
> 7  0x00007ffff767ed8a in Exiv2::XmpParser::decode(Exiv2::XmpData&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) () at /usr/lib/libexiv2.so.26
> 8  0x00007ffff75e5642 in Exiv2::JpegBase::readMetadata() () at /usr/lib/libexiv2.so.26
> 9  0x00007ffff7d794cf in  () at /usr/lib/libgexiv2.so.2
> 10 0x00007ffff7d79879 in gexiv2_metadata_open_path () at /usr/lib/libgexiv2.so.2

This calls https://felixcrux.com/files/doc/gexiv2_sys/fn.gexiv2_initialize.html,
which in turn calls
https://gitlab.gnome.org/GNOME/gexiv2/blob/bde3a816807ad998f80127b8df0263b036fdc732/gexiv2/gexiv2-startup.h#L23-33,
which calls
http://www.exiv2.org/doc/classExiv2_1_1XmpParser.html#aea661a7039adb5a748eb7639c8ce9294,
which mentions in its documentation:

Calling this method is usually not needed, as encode() and decode() will initialize the XMP Toolkit if necessary.

> The initialize() function itself still is not thread-safe and needs to be called
> in a thread-safe manner (e.g., on program startup), but if used with suitable
> additional locking parameters, any subsequent registration of namespaces will be
> thread-safe.