### PR TITLE
Add functions to add or set log level

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 #![crate_name = "rexiv2"]
 
 extern crate gexiv2_sys as gexiv2;
+pub use gexiv2::GExiv2LogLevel as LogLevel;
 
 use std::ffi;
 use std::ptr;
@@ -1078,6 +1079,31 @@ pub fn unregister_all_xmp_namespaces() {
     unsafe { gexiv2::gexiv2_metadata_unregister_all_xmp_namespaces() }
 }
 
+// Logging
+
+/// Get the GExiv2 log level.
+///
+/// # Examples
+/// ```
+/// assert_eq!(rexiv2::get_log_level(), rexiv2::LogLevel::WARN);
+/// rexiv2::set_log_level(rexiv2::LogLevel::INFO);
+/// assert_eq!(rexiv2::get_log_level(), rexiv2::LogLevel::INFO);
+/// ```
+pub fn get_log_level() -> LogLevel {
+    unsafe { gexiv2::gexiv2_log_get_level() }
+}
+
+/// Set the GExiv2 log level.
+///
+/// # Examples
+/// ```
+/// assert_eq!(rexiv2::get_log_level(), rexiv2::LogLevel::WARN);
+/// rexiv2::set_log_level(rexiv2::LogLevel::INFO);
+/// assert_eq!(rexiv2::get_log_level(), rexiv2::LogLevel::INFO);
+/// ```
+pub fn set_log_level(level: LogLevel) {
+    unsafe { gexiv2::gexiv2_log_set_level(level) }
+}
 
 // Private internal helpers.
 

--- a/tst/main.rs
+++ b/tst/main.rs
@@ -64,3 +64,10 @@ fn supports_xmp() {
     let meta = rexiv2::Metadata::new_from_buffer(include_bytes!("sample.png")).unwrap();
     assert_eq!(meta.supports_xmp(), true);
 }
+
+#[test]
+fn log_levels() {
+    assert_eq!(rexiv2::get_log_level(), rexiv2::LogLevel::WARN);
+    rexiv2::set_log_level(rexiv2::LogLevel::INFO);
+    assert_eq!(rexiv2::get_log_level(), rexiv2::LogLevel::INFO);
+}


### PR DESCRIPTION
Tests run fine and I've confirmed with the same corrupted image from issue #36 that those `WARNING`s don't show up after calling `rexiv2::set_log_level(rexiv2::LogLevel::ERROR)`.

This PR re-exports `gexiv2::GExiv2LogLevel` as `LogLevel`; adds `get_log_level() -> LogLevel` to get the current log level, and `set_log_level(level: gexiv2::LogLevel)` to set the current log level.