### PR TITLE
fix arm32

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,3 +10,4 @@ Contributors
 * Huon Wilson
 * Wieland Hoffmann
 * Jean-Baptiste Daval
+* Riley Trautman

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -876,7 +876,7 @@ impl PreviewImage<'_> {
             let ok = gexiv2::gexiv2_preview_image_write_file(image, c_str_path.as_ptr());
             gexiv2::gexiv2_preview_image_free(image);
 
-            let expected = self.get_size() as i64;
+            let expected = self.get_size() as libc::c_long;
             if ok != expected {
                 Err(Rexiv2Error::Internal(None))
             } else {


### PR DESCRIPTION
`ok` is a c_long, which means on different architectures it could be different sizes. This change fixes the build for arm32 by casting `expected` to a `c_long` instead of an `i64`