### PR TITLE
Expose functions to get GPS latitude, longitude and altitude separately

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,3 +11,4 @@ Contributors
 * Wieland Hoffmann
 * Jean-Baptiste Daval
 * Riley Trautman
+* Jonas Hagen

--- a/examples/gps.rs
+++ b/examples/gps.rs
@@ -4,8 +4,20 @@ use rexiv2::Metadata;
 
 fn main() {
     if let Ok(meta) = Metadata::new_from_path("examples/example.jpg") {
-        if let Some(location) = meta.get_gps_info() {
-            println!("Location: {:?}", location);
+        if let Some(lat) = meta.get_gps_latitude() {
+            println!("Latitude: {:?}", lat);
+        } else {
+            println!("No latitude found.");
+        }
+        if let Some(lon) = meta.get_gps_longitude() {
+            println!("Longitude: {:?}", lon);
+        } else {
+            println!("No longitude found.");
+        }
+        if let Some(alt) = meta.get_gps_altitude() {
+            println!("Altitude: {:?}", alt);
+        } else {
+            println!("No altitude found.");
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -785,6 +785,33 @@ impl Metadata {
 
     // GPS-related methods.
 
+    /// Retrieve the stored GPS latitude from the loaded file.
+    pub fn get_gps_latitude(&self) -> Option<f64> {
+        let lat = &mut 0.0;
+        match unsafe { gexiv2::gexiv2_metadata_get_gps_latitude(self.raw, lat) } {
+            0 => None,
+            _ => Some(*lat),
+        }
+    }
+
+    /// Retrieve the stored GPS longitude from the loaded file.
+    pub fn get_gps_longitude(&self) -> Option<f64> {
+        let lon = &mut 0.0;
+        match unsafe { gexiv2::gexiv2_metadata_get_gps_longitude(self.raw, lon) } {
+            0 => None,
+            _ => Some(*lon),
+        }
+    }
+
+    /// Retrieve the stored GPS altitude from the loaded file.
+    pub fn get_gps_altitude(&self) -> Option<f64> {
+        let alt = &mut 0.0;
+        match unsafe { gexiv2::gexiv2_metadata_get_gps_altitude(self.raw, alt) } {
+            0 => None,
+            _ => Some(*alt),
+        }
+    }
+
     /// Retrieve the stored GPS information from the loaded file.
     pub fn get_gps_info(&self) -> Option<GpsInfo> {
         let lon = &mut 0.0;


### PR DESCRIPTION
Suggestion: A possible (partial?) solution to #42.

The gexiv2 functions to access GPS latitude, longitude and altitude are exposed. The already present function `get_gps_info()` returns None if the altitude is not set. These newly exposed functions allow access to latitude and longitude in this (quite common) case.