### PR TITLE
Make altitude optional in GPS info

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,3 +11,4 @@ Contributors
 * Wieland Hoffmann
 * Jean-Baptiste Daval
 * Riley Trautman
+* Jonas Hagen

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,7 +107,7 @@ pub struct PreviewImage<'a> {
 pub struct GpsInfo {
     pub longitude: f64,
     pub latitude: f64,
-    pub altitude: f64,
+    pub altitude: Option<f64>,
 }
 
 /// The possible data types that a tag can have.
@@ -814,27 +814,25 @@ impl Metadata {
 
     /// Retrieve the stored GPS information from the loaded file.
     pub fn get_gps_info(&self) -> Option<GpsInfo> {
-        let lon = &mut 0.0;
-        let lat = &mut 0.0;
-        let alt = &mut 0.0;
-        match unsafe { gexiv2::gexiv2_metadata_get_gps_info(self.raw, lon, lat, alt) } {
-            0 => None,
-            _ => Some(GpsInfo {
-                longitude: *lon,
-                latitude: *lat,
-                altitude: *alt,
+        let lat = self.get_gps_latitude();
+        let lon = self.get_gps_longitude();
+        let altitude = self.get_gps_altitude();
+
+        match (lat, lon) {
+            (Some(latitude), Some(longitude)) => Some(GpsInfo {
+                latitude,
+                longitude,
+                altitude,
             }),
+            _ => None,
         }
     }
 
-    /// Save the specified GPS values to the metadata.
-    pub fn set_gps_info(&self, gps: &GpsInfo) -> Result<()> {
+    /// Save the specified GPS coordinates to the metadata.
+    pub fn set_gps_info(&self, latitude: f64, longitude: f64, altitude: f64) -> Result<()> {
         unsafe {
             int_bool_to_result(gexiv2::gexiv2_metadata_set_gps_info(
-                self.raw,
-                gps.longitude,
-                gps.latitude,
-                gps.altitude,
+                self.raw, longitude, latitude, altitude,
             ))
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -785,6 +785,33 @@ impl Metadata {
 
     // GPS-related methods.
 
+    /// Retrieve the stored GPS latitude from the loaded file.
+    pub fn get_gps_latitude(&self) -> Option<f64> {
+        let lat = &mut 0.0;
+        match unsafe { gexiv2::gexiv2_metadata_get_gps_latitude(self.raw, lat) } {
+            0 => None,
+            _ => Some(*lat),
+        }
+    }
+
+    /// Retrieve the stored GPS longitude from the loaded file.
+    pub fn get_gps_longitude(&self) -> Option<f64> {
+        let lon = &mut 0.0;
+        match unsafe { gexiv2::gexiv2_metadata_get_gps_longitude(self.raw, lon) } {
+            0 => None,
+            _ => Some(*lon),
+        }
+    }
+
+    /// Retrieve the stored GPS altitude from the loaded file.
+    pub fn get_gps_altitude(&self) -> Option<f64> {
+        let alt = &mut 0.0;
+        match unsafe { gexiv2::gexiv2_metadata_get_gps_altitude(self.raw, alt) } {
+            0 => None,
+            _ => Some(*alt),
+        }
+    }
+
     /// Retrieve the stored GPS information from the loaded file.
     pub fn get_gps_info(&self) -> Option<GpsInfo> {
         let lon = &mut 0.0;


### PR DESCRIPTION
This implies: For setting GPS info, the three components need to be supplied explicitly and separate.
This is not ideal because of the asymmetry in get / set GPS info. Since gexiv2 does not export a method to set the coordinates separately, this is the best option if altitude shall be optional in GPS Info.

See discussion in #42 (alternative solution in #43 ).