### PR TITLE
Set up linting and format checking in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,10 +2,9 @@ version: 2.1
 
 
 commands:
-  build_and_test_steps:
-    description: "Build the library and test it"
+  install_system_dependencies:
+    description: "Install system-level libraries/tools we depend on"
     steps:
-      - checkout
       - run:
           name: Install system dependencies
           command: |
@@ -19,6 +18,11 @@ commands:
                 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
                 ;;
             esac
+  build_and_test_steps:
+    description: "Build the library and test it"
+    steps:
+      - checkout
+      - install_system_dependencies
       - run:
           name: Show environment info
           command: |
@@ -50,29 +54,42 @@ linux_job_config: &linux_job_config
 
 
 jobs:
-  linux-msrv:
+  test-linux-msrv:
     docker:
       - image: rust:1.56-slim
     <<: *linux_job_config
-  linux-stable:
+  test-linux-stable:
     docker:
       - image: rust:slim
     <<: *linux_job_config
-  linux-nightly:
+  test-linux-nightly:
     docker:
       - image: rustlang/rust:nightly-slim
     <<: *linux_job_config
-  osx-stable:
+  test-osx-stable:
     macos:
       xcode: "14.0.0"
     steps:
       - build_and_test_steps
+  lint-and-format:
+    docker:
+      - image: rustlang/rust:nightly-slim
+    steps:
+      - checkout
+      - install_system_dependencies
+      - run:
+          name: Run linter
+          command: cargo +nightly clippy
+      - run:
+          name: Check formatting
+          command: cargo +nightly fmt --check
 
 
 workflows:
   build-and-test:
     jobs:
-      - linux-msrv
-      - linux-stable
-      - linux-nightly
-      - osx-stable
+      - test-linux-msrv
+      - test-linux-stable
+      - test-linux-nightly
+      - test-osx-stable
+      - lint-and-format

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(clippy::needless_doctest_main)]
+
 //! This library provides a Rust wrapper around the [gexiv2][gexiv2] library,
 //! which is itself a GObject-based wrapper around the [Exiv2][exiv2] library,
 //! which provides read and write access to the Exif, XMP, and IPTC metadata
@@ -47,7 +49,7 @@ use std::str;
 use std::os::unix::ffi::OsStrExt;
 
 /// A wrapper type for the kinds of errors one might encounter when using the library.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Rexiv2Error {
     /// No value found
     NoValue,
@@ -90,13 +92,13 @@ impl From<str::Utf8Error> for Rexiv2Error {
 pub type Result<T> = std::result::Result<T, Rexiv2Error>;
 
 /// An opaque structure that serves as a container for a media file's metadata.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Metadata {
     raw: *mut gexiv2::GExiv2Metadata,
 }
 
 /// An opaque structure that serves as a container for a preview image.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PreviewImage<'a> {
     raw: *mut gexiv2::GExiv2PreviewProperties,
     metadata: &'a Metadata, // Parent metadata to load a PreviewImage from a PreviewProperties.
@@ -111,7 +113,7 @@ pub struct GpsInfo {
 }
 
 /// The possible data types that a tag can have.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum TagType {
     /// Exif BYTE type, 8-bit unsigned integer.
     UnsignedByte,
@@ -773,10 +775,7 @@ impl Metadata {
             let mut n = 0;
             while !(*ptr.offset(n)).is_null() {
                 let preview_prop = *ptr.offset(n);
-                previews.push(PreviewImage {
-                    raw: preview_prop,
-                    metadata: self,
-                });
+                previews.push(PreviewImage { raw: preview_prop, metadata: self });
                 n += 1;
             }
             Some(previews)
@@ -792,11 +791,7 @@ impl Metadata {
         let alt = &mut 0.0;
         match unsafe { gexiv2::gexiv2_metadata_get_gps_info(self.raw, lon, lat, alt) } {
             0 => None,
-            _ => Some(GpsInfo {
-                longitude: *lon,
-                latitude: *lat,
-                altitude: *alt,
-            }),
+            _ => Some(GpsInfo { longitude: *lon, latitude: *lat, altitude: *alt }),
         }
     }
 

--- a/tst/main.rs
+++ b/tst/main.rs
@@ -93,7 +93,7 @@ fn supports_bmff() {
     // after gexiv2 has been initialized (and the underlying libraries are the
     // right version gexiv2 v0.13.0/Exiv2 v0.27.4)
     if unsafe { gexiv2::gexiv2_get_version() } < 1300 {
-      return;
+        return;
     }
 
     let meta = rexiv2::Metadata::new_from_buffer(include_bytes!("sample.HEIC")).unwrap();


### PR DESCRIPTION
For now, this has to use the nightly version of Cargo/rustfmt, because I
really want to preserve the multiple newlines between sections of code,
and that requires the `blank_lines_upper_bound` configuration option in
`.rustfmt.toml`. See https://github.com/rust-lang/rustfmt/issues/3381 for the bug tracking the
stabilization of this configuration option.