### PR TITLE
Set up test code coverage reporting as part of CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,11 @@ linux_job_config: &linux_job_config
 
 
 jobs:
+  test-osx-stable:
+    macos:
+      xcode: "14.0.0"
+    steps:
+      - build_and_test_steps
   test-linux-msrv:
     docker:
       - image: rust:1.56-slim
@@ -66,16 +71,41 @@ jobs:
     docker:
       - image: rust:slim
     <<: *linux_job_config
-  test-linux-nightly:
+  test-linux-nightly-with-coverage:
+    resource_class: large
     docker:
       - image: rustlang/rust:nightly-slim
-    <<: *linux_job_config
-  test-osx-stable:
-    macos:
-      xcode: "14.0.0"
     steps:
-      - build_and_test_steps
-  lint-and-format:
+      - checkout
+      - install_system_dependencies
+      - run:
+          name: Install test coverage reporting dependencies
+          command: |
+            rustup component add llvm-tools-preview
+            cargo install grcov
+            apt install --yes curl gpg git
+            curl https://keybase.io/codecovsecurity/pgp_keys.asc \
+                | gpg --no-default-keyring --keyring keys.gpg --import
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            gpg --keyring keys.gpg --verify codecov.SHA256SUM.sig codecov.SHA256SUM
+            sha256sum --check codecov.SHA256SUM
+            chmod +x codecov
+      - run:
+          name: Run tests with coverage analysis
+          command: |
+            RUSTFLAGS="-C instrument-coverage" \
+            RUSTDOCFLAGS="-C instrument-coverage -Z unstable-options --persist-doctests target/debug/doctestbins" \
+            LLVM_PROFILE_FILE="coverage-%p-%m.profraw" \
+            cargo test --all-features
+      - run:
+          name: Upload coverage report to Codecov
+          command: |
+            grcov . --binary-path ./target/debug/ -t lcov --branch \
+                --keep-only '/root/project/src/*' -o ./lcov.info
+            ./codecov -Z
+  check-lint-and-format:
     resource_class: small
     docker:
       - image: rustlang/rust:nightly-slim
@@ -102,9 +132,9 @@ jobs:
 workflows:
   build-and-test:
     jobs:
+      - test-osx-stable
       - test-linux-msrv
       - test-linux-stable
-      - test-linux-nightly
-      - test-osx-stable
-      - lint-and-format
+      - test-linux-nightly-with-coverage
+      - check-lint-and-format
       - check-spdx

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ rexiv2
 ======
 
 [![build-badge][]][build]&nbsp;
+[![coverage-badge][]][coverage]&nbsp;
 [![downloads-badge][]][crates-io]&nbsp;
 [![version-badge][]][crates-io]&nbsp;
 [![license-badge][]][license]&nbsp;
@@ -14,13 +15,15 @@ rexiv2
 
 [build]: https://dl.circleci.com/status-badge/redirect/gh/felixc/rexiv2/tree/main
 [build-badge]: https://dl.circleci.com/status-badge/img/gh/felixc/rexiv2/tree/main.svg?style=shield
+[coverage]: https://codecov.io/gh/felixc/rexiv2
+[coverage-badge]: https://codecov.io/gh/felixc/rexiv2/branch/master/graph/badge.svg?token=FT6WmJ9pD1
 [crates-io]: https://crates.io/crates/rexiv2
 [downloads-badge]: https://img.shields.io/crates/d/rexiv2.svg
 [version-badge]: https://img.shields.io/crates/v/rexiv2.svg
 [license]: https://github.com/felixc/rexiv2/blob/master/LICENSE
 [license-badge]: https://img.shields.io/crates/l/rexiv2.svg
-[reuse-badge]: https://api.reuse.software/badge/github.com/felixc/rexiv2
 [reuse]: https://api.reuse.software/info/github.com/felixc/rexiv2
+[reuse-badge]: https://api.reuse.software/badge/github.com/felixc/rexiv2
 
 
 Rust library for working with media file metadata


### PR DESCRIPTION
The `-Z` option to `codecov` is required in order for it to exit with a
non-success status code if there is an error, which we want in order to
make the CI step fail if there's a problem.

This was set up using:
  https://www.collabora.com/news-and-blog/blog/2021/03/24/rust-integrating-llvm-source-base-code-coverage-with-gitlab/
  https://doc.rust-lang.org/rustc/instrument-coverage.html
  https://github.com/mozilla/grcov