### PR TITLE
Changed creation of c_str_path variables, removing usage of std::os::unix::ffi::OsStrExt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ SPDX-License-Identifier: CC0-1.0
 
 ## [NEXT] - Unreleased
   * New API: new_from_app1_segment allows reading metadata from a buffer.
+  * Added support for Windows file paths.
   * Require Rust 1.63 as the minimum supported language version.
   * Adopt 2021 edition of the language.
   * Dependency upgrades.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -18,3 +18,4 @@ Contributors
 * Riley Trautman
 * Sean Dawson
 * Hubert Figuière
+* Tobias Prisching


### PR DESCRIPTION
To propose a solution for [#59](https://github.com/felixc/rexiv2/issues/59#issue-1376907301) I changed the creation of the c_str_path variables used in some functions (e.g. `new_from_path`) by inserting a conversion of `OsStr` to `str` first, before calling `as_bytes()`, eliminating the need for the usage of `std::os::unix::ffi::OsStrExt`, making the library hopefully compile under windows (as I don't have a Windows machine at hand I could not test it yet, but as the errors mentioned in the issue only involve the usage of the unix related functions there is a good chance that this resolves the issue). I left a copy of the old version in as a comment (line 279) above the new conversion for comparison.

Running all tests (using `cargo test`) results in none of them failing. As at least one test includes a call to `new_from_path`, where the new conversion gets used without problems, the proposed solution should be fine. 