### PR TITLE
Metadata::get_tag_rational(): avoid panic if denominator is 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -880,7 +880,13 @@ impl Metadata {
             gexiv2::gexiv2_metadata_get_exif_tag_rational(self.raw, c_str_tag.as_ptr(), num, den)
         } {
             0 => None,
-            _ => Some(num_rational::Ratio::new(*num, *den)),
+            _ => {
+                if *den != 0 {
+                    Some(num_rational::Ratio::new(*num, *den))
+                } else {
+                    None
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This happen if the tag doesn't exist.

```
stack backtrace:
   0: rust_begin_unwind
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:142:14
   2: core::panicking::panic
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:48:5
   3: num_rational::Ratio<T>::reduce
   4: rexiv2::Metadata::get_tag_rational
```

(the tag doesn't exist)