### PR TITLE
Do not reduce/simplify rational values (i.e. 16/10 is not 8/5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ SPDX-FileCopyrightText: 2015–2022 Felix A. Crux <felixc@felixcrux.com> and CON
 SPDX-License-Identifier: CC0-1.0
 -->
 
+## [NEXT] - Unreleased
+  * Bugfix: Stop reducing/simplifying rational values like apertures.
+
 ## [v0.10.0] - 2023-01-21
   * New API: `new_from_app1_segment` allows reading metadata from a buffer.
   * Added support for Windows file paths.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -882,7 +882,7 @@ impl Metadata {
             0 => None,
             _ => {
                 if *den != 0 {
-                    Some(num_rational::Ratio::new(*num, *den))
+                    Some(num_rational::Ratio::new_raw(*num, *den))
                 } else {
                     None
                 }
@@ -999,7 +999,13 @@ impl Metadata {
         let den = &mut 0;
         match unsafe { gexiv2::gexiv2_metadata_get_exposure_time(self.raw, num, den) } {
             0 => None,
-            _ => Some(num_rational::Ratio::new(*num, *den)),
+            _ => {
+                if *den != 0 {
+                    Some(num_rational::Ratio::new_raw(*num, *den))
+                } else {
+                    None
+                }
+            }
         }
     }
 

--- a/tst/main.rs
+++ b/tst/main.rs
@@ -132,6 +132,34 @@ fn supports_bmff() {
 }
 
 #[test]
+fn get_tag_rational_values_are_not_reduced() {
+    test_setup();
+    let meta = rexiv2::Metadata::new_from_buffer(include_bytes!("sample.png")).unwrap();
+    meta.set_tag_rational(
+        "Exif.Photo.ApertureValue",
+        &num_rational::Ratio::new_raw(16, 10),
+    )
+    .unwrap();
+    let result = meta.get_tag_rational("Exif.Photo.ApertureValue").unwrap();
+    assert_eq!(*result.numer(), 16);
+    assert_eq!(*result.denom(), 10);
+}
+
+#[test]
+fn get_exposure_time_values_are_not_reduced() {
+    test_setup();
+    let meta = rexiv2::Metadata::new_from_buffer(include_bytes!("sample.png")).unwrap();
+    meta.set_tag_rational(
+        "Exif.Photo.ExposureTime",
+        &num_rational::Ratio::new_raw(10, 1000),
+    )
+    .unwrap();
+    let result = meta.get_exposure_time().unwrap();
+    assert_eq!(*result.numer(), 10);
+    assert_eq!(*result.denom(), 1000);
+}
+
+#[test]
 fn log_levels() {
     test_setup();
     assert_eq!(rexiv2::get_log_level(), rexiv2::LogLevel::WARN);


### PR DESCRIPTION
`num_rational::Ratio::new()` by default simplifies/reduces rational values to their standard form. This means apertures, exposures, and the like would get mangled. We can avoid this by using `new_raw()` instead and checking for 0 denominators ourselves.

Fixes #64