### PR TITLE
Make altitude component of GpsInfo optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ SPDX-License-Identifier: CC0-1.0
 
 ## [NEXT] - Unreleased
   * Bugfix: Stop reducing/simplifying rational values like apertures.
+  * Breaking API change/bugfix: The altitude part of GpsInfo is now Optional.
+    This works around an upstream change that caused `get_gps_info` to return
+    `None` if altitude was unset, even if lat/long were present. Now lat/long
+    will be returned, but altitude will be `None`. Altitudes that may have been
+    previously shown as `0.0` will now be `None`. Calls to `set_gps_info` will
+    also need updating. Thank you Jonas Hagen for the report and investigation.
 
 ## [v0.10.0] - 2023-01-21
   * New API: `new_from_app1_segment` allows reading metadata from a buffer.


### PR DESCRIPTION
This matches the real-world behaviour of apps that only set lat/long when drawing points on a map.

What made this tricky is that up until gexiv2 0.12.2, this was not necessary. If altitude (or indeed latitude or longitude) were missing, the function would still return successfully overall as long as at least one piece of data could be found. However in 0.12.2 this changes so that *all three* components need to be present for `gexiv2_metadat_get_gps_info` to return `TRUE`.

I am not sure if this change was intentional, so I have filed a bug upstream with gexiv2, but in the meantime we still need a workaround. Bug report: https://gitlab.gnome.org/GNOME/gexiv2/-/issues/72

Debian Stable as of today ships with 0.12.1, so I couldn't reproduce or test this locally, but the CircleCI Mac OSX executor is installing a recent version of the library via homebrew, so if the tests pass there it should be good.

This patch works around the problem by making the altitude (and only altitude) component of `GpsInfo` `Optional`. This is slightly annoyingly asymmetrical, but makes sense in reality as there's no reason to have, say, a latitude and an altitude but not a longitude. The workaround relies on the implementation detail that gexiv2 upstream happens to check and set latitude and longitude first, and altitude last. That means that even if we get a `FALSE` return, the latitude and longitude pointers may nonetheless have been populated, if the problem was simply that altitude was unset.

For compatibility with various versions of gexiv2, we handle both cases: the newer behaviour that returns `FALSE`, and also the older behaviour that returns `TRUE` but has altitude set to `0.0`.

Addresses bug report #42

References:
  - 0.12.1 version of the code: https://gitlab.gnome.org/GNOME/gexiv2/blob/gexiv2-0.12.1/gexiv2/gexiv2-metadata-gps.cpp#L186
  - 0.12.2 version: https://gitlab.gnome.org/GNOME/gexiv2/blob/gexiv2-0.12.2/gexiv2/gexiv2-metadata-gps.cpp#L246
  - Commit that made the change: https://gitlab.gnome.org/GNOME/gexiv2/-/commit/f2d96b4df221d922ededfbff9236636273a56029