### PR TITLE
Check `GBytes*` isn't `NULL` in `get_tag_raw()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ SPDX-License-Identifier: CC0-1.0
     will be returned, but altitude will be `None`. Altitudes that may have been
     previously shown as `0.0` will now be `None`. Calls to `set_gps_info` will
     also need updating. Thank you Jonas Hagen for the report and investigation.
+  * Fix glib error message from `get_tag_raw()` if the tag doesn't exist.
 
 ## [v0.10.0] - 2023-01-21
   * New API: `new_from_app1_segment` allows reading metadata from a buffer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -944,17 +944,21 @@ impl Metadata {
         let c_str_tag = ffi::CString::new(tag)?;
         unsafe {
             let raw_tag_value = gexiv2::gexiv2_metadata_get_tag_raw(self.raw, c_str_tag.as_ptr());
-            let size = &mut 0;
-            let ptr = glib_sys::g_bytes_get_data(raw_tag_value, size) as *const u8;
-            let result = if ptr.is_null() {
+            if raw_tag_value.is_null() {
                 Err(Rexiv2Error::NoValue)
             } else {
-                // Make a copy here
-                // Could be optimized out but need to keep a reference to the returned GByte object
-                Ok(std::slice::from_raw_parts(ptr, *size).to_owned())
-            };
-            glib_sys::g_bytes_unref(raw_tag_value);
-            result
+                let size = &mut 0;
+                let ptr = glib_sys::g_bytes_get_data(raw_tag_value, size) as *const u8;
+                let result = if ptr.is_null() {
+                    Err(Rexiv2Error::NoValue)
+                } else {
+                    // Make a copy here
+                    // Could be optimized out but need to keep a reference to the returned GByte object
+                    Ok(std::slice::from_raw_parts(ptr, *size).to_owned())
+                };
+                glib_sys::g_bytes_unref(raw_tag_value);
+                result
+            }
         }
     }
 


### PR DESCRIPTION
If the tag doesn't exist it generates error messages from glib:
`GLib-CRITICAL **: g_bytes_get_data: assertion 'bytes != NULL' failed`